### PR TITLE
Have aushape support audit-lib-2.4.5 - ie RHEL6 releases

### DIFF
--- a/aushape.spec
+++ b/aushape.spec
@@ -22,8 +22,9 @@ formats.
 %setup -q
 
 %build
-%configure --disable-rpath --disable-static
-make %{?_smp_mflags}
+autoreconf -i -f
+%configure --disable-rpath --disable-static AUDIT_LIB_VERSION=$(printf "%03d%03d%03d" $(echo `rpm -q --qf '%{VERSION}' audit-libs` | tr '.' ' '))
+make %{?_smp_mflags} 
 
 %check
 make %{?_smp_mflags} check
@@ -41,5 +42,6 @@ rm -r %{buildroot}/usr/include/%{name}
 %license COPYING.LESSER
 %{_bindir}/%{name}
 %{_libdir}/lib%{name}.so*
-
+%attr(644,root,root) /usr/include/aushape.h
+%attr(644,root,root) /usr/share/doc/aushape/README.md
 %changelog

--- a/configure.ac
+++ b/configure.ac
@@ -26,8 +26,14 @@ AM_MAINTAINER_MODE
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_GNU_SOURCE
+# We define AUDIT_LIB_VERSION so we can, at compile time work our the version of audit-libs available
+# as we need to conditionally compile depending on the version
+# This means our packaging build could run
+#  ./configure ... AUDIT_LIB_VERSION=$(printf "%03d%03d%03d" $(echo `rpm -q --qf '%{VERSION}' audit-libs` | tr '.' ' '))
+# or
+#  ./configure ... AUDIT_LIB_VERSION=$(printf "%03d%03d%03d" $(echo `dpkg-query --showformat='${Version}' --show libauparse0` | cut -d: -f2 | cut -d- -f1 | tr '.' ' '))
 ABS_SRCDIR=`cd ${srcdir}; pwd`
-CPPFLAGS="-I${ABS_SRCDIR} -I${ABS_SRCDIR}/include -DNDEBUG $CPPFLAGS"
+CPPFLAGS="-I${ABS_SRCDIR} -I${ABS_SRCDIR}/include -DNDEBUG -DAUDIT_LIB_VERSION=$AUDIT_LIB_VERSION $CPPFLAGS"
 
 # Check for programs.
 AC_PROG_CC

--- a/lib/conv.c
+++ b/lib/conv.c
@@ -195,7 +195,27 @@ aushape_conv_create(struct aushape_conv **pconv,
 
     conv->au = auparse_init(AUSOURCE_FEED, NULL);
     AUSHAPE_GUARD_BOOL(AUPARSE_FAILED, conv->au != NULL);
+    /*
+     * Some trickery to support different versions of auparse_set_escape_mode().
+     * It was given an additional argument in audit-libs version 2.6.2.
+     * So we can compile for older versions we
+     * a. Default of null AUDIT_LIB_VERSION assumes the new version
+     * b. We test the version strings
+     */
+#if	(AUDIT_LIB_VERSION + 0)
+
+#if	AUDIT_LIB_VERSION < 002006002 
+    auparse_set_escape_mode(AUPARSE_ESC_RAW);
+#else	/* AUDIT_LIB_VERSION < 002006002 */
     auparse_set_escape_mode(conv->au, AUPARSE_ESC_RAW);
+#endif	/* AUDIT_LIB_VERSION < 002006002 */
+
+#else 	/* AUDIT_LIB_VERSION is null */
+
+    auparse_set_escape_mode(conv->au, AUPARSE_ESC_RAW);
+
+#endif	/* AUDIT_LIB_VERSION is null */
+
     auparse_add_callback(conv->au, aushape_conv_cb, conv, NULL);
 
     conv->format = *format;

--- a/lib/field.c
+++ b/lib/field.c
@@ -50,7 +50,10 @@ aushape_field_format(struct aushape_gbuf *gbuf,
 
     switch (type) {
     case AUPARSE_TYPE_ESCAPED:
+    /* This field type was introduced in audit-libs 2.6.6 */
+#ifdef	AUPARSE_TYPE_ESCAPED_KEY
     case AUPARSE_TYPE_ESCAPED_KEY:
+#endif	/* def AUPARSE_TYPE_ESCAPED_KEY */
         value_r = NULL;
         break;
     default:


### PR DESCRIPTION
Aushape uses auparse capability introduced at the audit-2.6.2 release.

In order to compile aushape on older Linux systems where audit is at say release 2.4.5, a simple patch has been applied to the code and, in the case of the rpm spec file, modified there.

Basically this is to support RHEL6/Centos6 or Ubuntu 16.04 (Xenial)