### PR TITLE
Fixe path for /usr/bin/aushape-audispd-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ You can then add it to Audispd configuration by putting this into
 
     active = yes
     direction = out
-    path = /usr/local/bin/aushape-audispd-plugin
+    path = /usr/bin/aushape-audispd-plugin
     type = always
     format = string
 


### PR DESCRIPTION
The path to /usr/bin/aushape-audispd-plugin must be the same in /etc/audisp/plugins.d/aushape.conf